### PR TITLE
[Dev] ref #21 : 构建 ci 通用镜像族

### DIFF
--- a/ci/release/Dockerfile
+++ b/ci/release/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.license="MIT"
 LABEL arcesteam.role="ci-release-image"
 
 RUN apk add --no-cache \
-    gpg gh maven \
+    gpg maven \
     && rm -rf /var/cache/apk/*
 
 ENV CI_RELEASE=true


### PR DESCRIPTION
移除未获取到的 gh 工具，考虑到默认通过 GitHub Actions 执行，此处暂不处理